### PR TITLE
fix(ie10): fix issue while using 'super'

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
     require("babel-plugin-transform-es2015-arrow-functions"),
     require("babel-plugin-transform-es2015-block-scoped-functions"),
     require("babel-plugin-transform-es2015-block-scoping"),
-    require("babel-plugin-transform-es2015-classes"),
+    [require("babel-plugin-transform-es2015-classes"), { loose: true } ], // avoid ie10 and below issues with `extends` and `super`
     require("babel-plugin-transform-es2015-computed-properties"),
     require("babel-plugin-transform-es2015-destructuring"),
     require("babel-plugin-transform-es2015-for-of"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-bonita",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Babel preset for all Bonita plugins.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
See http://babeljs.io/docs/usage/caveats/

Classes (10 and below)

If you're inheriting from a class then static properties are inherited from it via **proto**, this is widely supported but you may run into problems with much older browsers.
NOTE: **proto** is not supported on IE <= 10 so static properties will not be inherited. See the protoToAssign for a possible work around.
For classes that have supers, the super class won't resolve correctly. You can get around this by enabling the loose option in the es2015-classes plugin.
